### PR TITLE
Fix a bug, and allow minLength 0.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -31,10 +31,11 @@
                   <input data-bind="attr: { size: inputSize }, hasfocus: focused, value: value, valueUpdate: 'afterkeydown', onBackspace: removeLast, autocomplete: { data: items, onSelect: select, separators: ',; ' }" value=""/>
               </div>
           </div>
-          <h2>Single Completion with Target</h2>
+          <h2>List Filtering with Target</h2>
           <div>
               <span class="label">C# keywords:</span>
-              <input data-bind="autocomplete: { data: keywords, target: 'targetSuggestions' }">
+              <input data-bind="autocomplete: { data: keywords, minLength: 0, target: 'targetSuggestions', onSelect: function (item) { flashWord(item); return ''; } }">
+              <b><span data-bind="text: flashWord"></span></b>
               <div id="targetSuggestions"></div>
           </div>
       </div>

--- a/examples/main.js
+++ b/examples/main.js
@@ -1,4 +1,4 @@
-/*global ko*/
+/*global ko, examples*/
 (function () {
     var keywords = [
         'abstract', 'add', 'alias', 'as', 'ascending', 'async', 'await', 'base', 'bool', 'break',
@@ -15,7 +15,17 @@
 
     var viewModel = {
         keywords: keywords,
-        multiComplete: new examples.MultiCompleteModel(keywords)
+        multiComplete: new examples.MultiCompleteModel(keywords),
+        flashWord: ko.observable()
     };
+
+    viewModel.flashWord.subscribe(function (newValue) {
+        setTimeout(function () {
+            if (viewModel.flashWord() === newValue) {
+                viewModel.flashWord('');
+            }
+        }, 1000);
+    });
+
     ko.applyBindings(viewModel, document.getElementById('application'));
 }());

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -138,7 +138,7 @@
 
             var format = options.format || defaultOptions.format;
             var maxItems = options.maxItems || defaultOptions.maxItems;
-            var minLength = options.minLength || defaultOptions.minLength;
+            var minLength = typeof options.minLength === 'number' ? options.minLength : defaultOptions.minLength;
             var separators = options.separators || defaultOptions.separators;
             separators = separators && new RegExp('[' + separators + ']');
 
@@ -478,6 +478,15 @@
                     selectSuggestion(0);
                 }
             });
+
+            if (suggestions().length) {
+                $dropdown.append(renderSuggestions($dropdown, suggestions()));
+                selectSuggestion(0);
+                if (options.target && minLength === 0) {
+                    $container.show();
+                    $dropdown.show();
+                }
+            }
 
             utils.domNodeDisposal.addDisposeCallback(element, function () {
                 query('');


### PR DESCRIPTION
The first commit fixes an oversight from the last PR.

The other allows the autocomple binding to be used to filter lists as well, by setting the minLength option to 0.
