### PR TITLE
Stop reacting to key events with modifiers (ctrl,, alt, etc.)

### DIFF
--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -288,6 +288,10 @@
             });
 
             $element.on("keydown", function (e) {
+                if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
+                    // This is a modified key event. Don't react to those.
+                    return true;
+                }
                 switch (e.which) {
                 case keys.up:
                     if (selectPrevious()) {


### PR DESCRIPTION
Also make sure to propagate them on to whomever might want to use them.
