### PR TITLE
Made it possible to feed in previously filtered data.

### DIFF
--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -149,7 +149,7 @@
                 return item.toString();
             };
 
-            var query = ko.observable('');
+            var query = ko.isObservable(options.query) ? options.query : ko.observable('');
 
             var selectedIndex = -1;
 
@@ -159,12 +159,16 @@
                 if (queryText.length < minLength) {
                     return [];
                 } else {
-                    var matches = utils.arrayFilter(data, function (item) {
-                        var label = format(item).toLowerCase();
-                        var offset = label.indexOf(queryText);
-                        return offset !== -1;
-                    }).slice(0, maxItems);
-
+                    var matches;
+                    if (options.noFilter) {
+                        matches = data;
+                    } else {
+                        matches = utils.arrayFilter(data, function (item) {
+                            var label = format(item).toLowerCase();
+                            var offset = label.indexOf(queryText);
+                            return offset !== -1;
+                        }).slice(0, maxItems);
+                    }
                     return arrayMap(matches, function (item) {
                         var label = format(item);
                         var offset = label.toLowerCase().indexOf(queryText);


### PR DESCRIPTION
I added the ability to give an observable to use as the query store, and an argument that disables filtering in the suggestion generating code. Adding both of these makes it the user's responsibility to filter the data fed to ko.autocomplete. Adding only the former permits eg. echoing of the current query. Adding only the latter allows the user to suggest a list based on external factors alone.
