### PR TITLE
Fixed IE issue with click on scrollbar blurring

### DIFF
--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -394,10 +394,12 @@
                 write: function (value) {
                     if (value) {
                         if (suggestions().length) {
+                            if (!this.state()) {
+                                $dropdown.on('mouseenter', mouseEnterDropdown)
+                                         .on('mouseleave', mouseLeaveDropdown);
+                             }
                             this.state(true);
                             updateVisibilityOption(true);
-                            $dropdown.on('mouseenter', mouseEnterDropdown)
-                                     .on('mouseleave', mouseLeaveDropdown);
                         }
                     } else {
                         if (!options.target || options.minLength > 0) {

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -458,8 +458,9 @@
                     // IE blurs the $element when clicking on the scroll bar.
                     // To ensure the dropdown does not close, we refocus the
                     // $element, when not closed intentionally by key press.
+                    e.preventDefault();
                     $element.focus();
-                    return;
+                    return false;
                 }
                 menuShown(false);
                 mouseInDropdown = false;

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -319,7 +319,7 @@
                 justPasted = true;
             });
 
-            var keyClose = ko.observable(false);
+            var keyClose = false;
 
             $element.on("keydown", function (e) {
                 if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
@@ -351,7 +351,7 @@
                     if (isMenuShown) {
                         menuShown(false);
                     } else {
-                        keyClose(true);
+                        keyClose = true;
                         $element.blur();
                     }
                     return bubble;
@@ -360,7 +360,7 @@
             });
 
             $element.on("keyup", function (e) {
-                keyClose(false);
+                keyClose = false;
                 if (justPasted || (separators && separators.test(element.value))) {
                     freeTextSelect();
                     justPasted = false;
@@ -377,14 +377,14 @@
                 }
             });
 
-            var mouseInDropdown = ko.observable(false);
+            var mouseInDropdown = false;
 
             function mouseEnterDropdown() {
-                mouseInDropdown(true);
+                mouseInDropdown = true;
             }
 
             function mouseLeaveDropdown() {
-                mouseInDropdown(false);
+                mouseInDropdown = false;
             }
 
             var menuShown = ko.computed({
@@ -454,14 +454,15 @@
             });
 
             $element.on('blur.autocomplete', function (e) {
-                if (menuShown() && mouseInDropdown() && !keyClose()) {
+                if (menuShown() && mouseInDropdown && !keyClose {
                     // IE blurs the $element when clicking on the scroll bar.
                     // To ensure the dropdown does not close, we refocus the
                     // $element, when not closed intentionally by key press.
                     $element.focus();
                     return;
                 }
-                 menuShown(false);
+                menuShown(false);
+                mouseInDropdown = false;
                 if (query() !== '') {
                     setTimeout(function () {
                         $(':focus').first().each(function (i, el) {

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -454,7 +454,7 @@
             });
 
             $element.on('blur.autocomplete', function (e) {
-                if (menuShown() && mouseInDropdown && !keyClose {
+                if (menuShown() && mouseInDropdown && !keyClose) {
                     // IE blurs the $element when clicking on the scroll bar.
                     // To ensure the dropdown does not close, we refocus the
                     // $element, when not closed intentionally by key press.

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -319,6 +319,8 @@
                 justPasted = true;
             });
 
+            var keyClose = ko.observable(false);
+
             $element.on("keydown", function (e) {
                 if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) {
                     // This is a modified key event. Don't react to those.
@@ -349,6 +351,7 @@
                     if (isMenuShown) {
                         menuShown(false);
                     } else {
+                        keyClose(true);
                         $element.blur();
                     }
                     return bubble;
@@ -357,6 +360,7 @@
             });
 
             $element.on("keyup", function (e) {
+                keyClose(false);
                 if (justPasted || (separators && separators.test(element.value))) {
                     freeTextSelect();
                     justPasted = false;
@@ -373,6 +377,16 @@
                 }
             });
 
+            var mouseInDropdown = ko.observable(false);
+
+            function mouseEnterDropdown() {
+                mouseInDropdown(true);
+            }
+
+            function mouseLeaveDropdown() {
+                mouseInDropdown(false);
+            }
+
             var menuShown = ko.computed({
                 read: function () {
                     return this.state();
@@ -382,11 +396,15 @@
                         if (suggestions().length) {
                             this.state(true);
                             updateVisibilityOption(true);
+                            $dropdown.on('mouseenter', mouseEnterDropdown)
+                                     .on('mouseleave', mouseLeaveDropdown);
                         }
                     } else {
                         if (!options.target || options.minLength > 0) {
                             this.state(false);
                             updateVisibilityOption(false);
+                            $dropdown.off('mouseenter', mouseEnterDropdown)
+                                     .off('mouseleave', mouseLeaveDropdown);
                         }
                     }
                 }
@@ -436,6 +454,13 @@
             });
 
             $element.on('blur.autocomplete', function (e) {
+                if (menuShown() && mouseInDropdown() && !keyClose()) {
+                    // IE blurs the $element when clicking on the scroll bar.
+                    // To ensure the dropdown does not close, we refocus the
+                    // $element, when not closed intentionally by key press.
+                    $element.focus();
+                    return;
+                }
                  menuShown(false);
                 if (query() !== '') {
                     setTimeout(function () {

--- a/test/index.html
+++ b/test/index.html
@@ -2,17 +2,23 @@
   <head>
     <title>Mocha</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <link rel="stylesheet" href="../lib/knockout.autocomplete.css" />
     <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
     <style>
-     .floating-menu {
-         visibility: hidden;
-     }
+        .autocomplete, .floating-menu {
+            width: 180px;
+        }
+
+        .floating-menu {
+            max-height: 200px;
+            overflow-y: auto;
+        }
     </style>
   </head>
   <body>
     <div id="mocha"></div>
 
-    <div style="display: none" id="test"></div>
+    <div style="position: absolute; top: 0; left: -9999px;" id="test"></div>
 
     <!-- Test elements -->
 

--- a/test/knockout.autocomplete.spec.js
+++ b/test/knockout.autocomplete.spec.js
@@ -143,4 +143,51 @@ describe('knockout.autocomplete', function () {
             });
         });
     });
+
+    describe('tracking when the mouse is over the floating menu', function () {
+        beforeEach(function () {
+            $testElement = useTestElement('<input data-bind="autocomplete: { data: keywords, minLength: 0 }" value="">');
+            viewModel = {
+                data: ko.observable(keywords)
+            };
+            ko.applyBindings(viewModel, $testElement[0]);
+        });
+
+        describe('attaching enter/leave event to the dropdown', function () {
+            describe('when changing the query phase', function () {
+                var beforeOverEvents;
+                var beforeOutEvents;
+                beforeEach(function () {
+                    var menuEvents = $._data( $('.floating-menu')[0], 'events');
+                    beforeOverEvents = menuEvents.mouseover && menuEvents.mouseover.length || 0;
+                    beforeOutEvents = menuEvents.mouseout && menuEvents.mouseout.length || 0;
+
+                    $testElement.val('fi').trigger('change');
+                    keyUp($testElement);
+
+                    $testElement.val('fin').trigger('change');
+                    keyUp($testElement);
+
+                    $testElement.val('fina').trigger('change');
+                    keyUp($testElement);
+
+                    $testElement.val('final').trigger('change');
+                    keyUp($testElement);
+                });
+
+                it('should only have add one enter event', function () {
+                    var menuEvents = $._data( $('.floating-menu')[0], 'events');
+
+                    expect(menuEvents.mouseover.length - beforeOverEvents, 'to equal', 1);
+                });
+
+                it('should only have add one leave event', function () {
+                    var menuEvents = $._data( $('.floating-menu')[0], 'events');
+
+                    expect(menuEvents.mouseout.length - beforeOutEvents, 'to equal', 1);
+                });
+
+            });
+        });
+    });
 });

--- a/test/knockout.autocomplete.spec.js
+++ b/test/knockout.autocomplete.spec.js
@@ -79,4 +79,68 @@ describe('knockout.autocomplete', function () {
             });
         });
     });
+
+    describe('blurring autocomplete element', function () {
+        beforeEach(function () {
+            $testElement = useTestElement('<input data-bind="autocomplete: { data: keywords, minLength: 0 }" value="">');
+            viewModel = {
+                data: ko.observable(keywords)
+            };
+            ko.applyBindings(viewModel, $testElement[0]);
+        });
+
+        describe('floating menu closed', function () {
+            beforeEach(function () {
+                $testElement.focus();
+            });
+
+            afterEach(function () {
+                keyUp($testElement);
+            });
+
+            it('should blur correctly on esc close', function () {
+                keyDown($testElement, { which: 27 }); // 27 = escape key
+
+                expect(document.activeElement, 'not to equal', $testElement[0]);
+            });
+
+            it('should blur correctly when mouse is away from element and floating menu', function () {
+                $('#mocha').trigger('mouseenter');
+                $testElement.blur();
+
+                expect(document.activeElement, 'not to equal', $testElement[0]);
+            });
+        });
+
+        describe('floating menu open', function () {
+            beforeEach(function () {
+                $testElement.val('pr').trigger('change');
+                keyUp($testElement);
+            });
+
+            afterEach(function () {
+                keyUp($testElement);
+            });
+
+            it('should blur correctly on esc close', function () {
+                keyDown($testElement, { which: 27 }); // 27 = escape key
+
+                expect(document.activeElement, 'not to equal', $testElement[0]);
+            });
+
+            it('should blur correctly when mouse is away from element and floating menu', function () {
+                $('#mocha').trigger('mouseenter');
+                $testElement.blur();
+
+                expect(document.activeElement, 'not to equal', $testElement[0]);
+            });
+
+            it('should not blur when mouse is over floating menu', function () {
+                $('.floating-menu').trigger('mouseenter');
+                $testElement.blur();
+
+                expect(document.activeElement, 'to equal', $testElement[0]);
+            });
+        });
+    });
 });


### PR DESCRIPTION
IE blurres the focused field when clicking on the scroll bar. This makes the dropdown unintentionally close.
This fix tracks close on ESC press and whether mouse is inside or outside of dropdown on blur. Based on those metrics, we can determine whether it's an intentional closing of the dropdown or a click on the scroll bar.