### PR TITLE
Added more update position events

### DIFF
--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -451,9 +451,9 @@
                 }
             }));
 
-            $window.on('scroll.autocomplete', function () {
-                positionMenu();
-            });
+            $window.on('scroll.autocomplete', positionMenu);
+            $window.on('resize.autocomplete', positionMenu);
+            $dropdown.on('scroll.autocomplete', positionMenu);
 
             $element.on('blur.autocomplete', function (e) {
                 if (menuShown() && mouseInDropdown && !keyClose) {
@@ -625,12 +625,15 @@
             }
 
             utils.domNodeDisposal.addDisposeCallback(element, function () {
+                $window.off('scroll.autocomplete', positionMenu);
+                $window.off('resize.autocomplete', positionMenu);
+                $dropdown.off('scroll.autocomplete', positionMenu);
+
                 query('');
                 $dropdown.remove();
                 subscriptions.forEach(function (subscription) {
                     subscription.dispose();
                 });
-                $window.off('scroll.autocomplete');
             });
 
         }

--- a/test/knockout.autocomplete.spec.js
+++ b/test/knockout.autocomplete.spec.js
@@ -19,6 +19,11 @@ var keywords = [
 describe('knockout.autocomplete', function () {
     var $testElement;
     var viewModel;
+
+    afterEach(function () {
+        clearTestElement();
+    });
+
     describe('simple completion', function () {
         beforeEach(function () {
             $testElement = useTestElement('<input data-bind="autocomplete: { data: keywords, maxItems: 6 }" value="">');
@@ -187,6 +192,42 @@ describe('knockout.autocomplete', function () {
                     expect(menuEvents.mouseout.length - beforeOutEvents, 'to equal', 1);
                 });
 
+            });
+        });
+    });
+
+    describe('Update position events', function () {
+        beforeEach(function () {
+            $testElement = useTestElement('<input data-bind="autocomplete: { data: keywords, minLength: 0 }" value="">');
+            viewModel = {
+                data: ko.observable(keywords)
+            };
+            ko.applyBindings(viewModel, $testElement[0]);
+        });
+
+        describe('added autocomplete element', function () {
+            it('should have scroll event on window', function () {
+                var events = $._data(window, 'events');
+                expect(events.scroll.length, 'to be', 1);
+            });
+            it('should have scroll event on dropdown container', function () {
+                var events = $._data(getMenu(), 'events');
+                expect(events.scroll.length, 'to be', 1);
+            });
+            it('should have resize event on window', function () {
+                var events = $._data(window, 'events');
+                expect(events.resize.length, 'to be', 1);
+            });
+
+            describe('after removing autocomplete element', function () {
+                beforeEach(function () {
+                    clearTestElement();
+                });
+
+                it('should not have events on window', function () {
+                    var events = $._data(window, 'events');
+                    expect(events, 'to be falsy');
+                });
             });
         });
     });

--- a/test/spec.helper.js
+++ b/test/spec.helper.js
@@ -1,6 +1,13 @@
 var expect = window.weknowhow.expect;
 expect.use(window.unexpected.dom);
 
+function clearTestElement() {
+    var $testElement = $('#test').find('*');
+    $testElement.each(function () {
+        ko.cleanNode(this);
+    });
+}
+
 function useTestElement(html) {
     var container = $('#test');
     container.empty();


### PR DESCRIPTION
When using this autocomplete component in a [popupTemplate](https://github.com/One-com/knockout-popupTemplate) and using this component as a dropdown (with scrolling in search results), then scrolling can in some cases trigger repositioning of the popupTemplate, but the autocomplete component dropdown will not follow the popupTemplates new position.

Therefore I've added reposition updates when scrolling, resizing and scrolling in the search dropdown.
Tests has been added to provide proof that the events are being removed to avoid memory leaks.