### PR TITLE
feature: appends the autocomplete after the target element

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ function (completionItem) {
 };
 ```
 
+#### after (default false)
+
+Append the autocomplete elemente after the target element (input). In this way, 
+the autocomplete can be positioned absolute but within a container sourounding 
+both input and autocomplete. See the example on how to use it.
+
 ### Examples
 
 [Click here to see an example](https://cdn.rawgit.com/One-com/knockout.autocomplete/master/examples/index.html)

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ function (completionItem) {
 
 #### after (default false)
 
-Append the autocomplete elemente after the target element (input). In this way, 
-the autocomplete can be positioned absolute but within a container sourounding 
+Appends the autocomplete element, after the target element (input). In this way, 
+the autocomplete can be positioned absolute, but within a container surrounding 
 both input and autocomplete. See the example on how to use it.
 
 ### Examples

--- a/examples/index.html
+++ b/examples/index.html
@@ -49,6 +49,13 @@
               <b><span data-bind="text: flashWord"></span></b>
               <div id="targetSuggestions"></div>
           </div>
+          <h2>After input element to contain dropdown</h2>
+          <div>
+              <span class="label">C# keywords</span>
+              <div class="after-container">
+                <input data-bind="autocomplete: { data: keywords, maxItems: 6, after: true }" value=""/>
+              </div>
+          </div>
       </div>
       <script type="text/javascript" src="../vendor/jquery-1.8.1.js"></script>
       <script type="text/javascript" src="../vendor/knockout-2.2.0.debug.js"></script>

--- a/examples/style.css
+++ b/examples/style.css
@@ -1,3 +1,7 @@
+body {
+    padding-bottom: 200px;
+}
+
 .completion {
     border: thin solid #aaa;
     display: inline-block;
@@ -47,4 +51,30 @@
     max-height: 200px;
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
+}
+
+.after-container {
+    position: relative;
+    width: 200px;
+}
+.after-container .after-menu {
+    border: 1px solid #82bed6;
+    margin: -1px 0 0 0;
+    width: 100%;
+    box-sizing: border-box;
+    padding: 0;
+    box-shadow: 0px 3px 3px -1px rgba(0,0,0,0.1);
+}
+.after-container .after-menu li {
+    background-color: #fff;
+    padding: 0.5em 0.8em;
+}
+.after-container input {
+    width: 100%;
+    padding: 4px;
+    box-sizing: border-box;
+}
+.after-container input:focus {
+    outline: none;
+    border: 1px solid #82bed6;
 }

--- a/lib/knockout.autocomplete.css
+++ b/lib/knockout.autocomplete.css
@@ -13,6 +13,10 @@
     box-shadow:         1px 1px 4px rgba(50, 50, 50, 0.75);
 }
 
+.knockout-autocomplete.after-menu {
+    position: absolute;
+}
+
 .knockout-autocomplete.menu li {
     cursor: pointer;
     list-style: none;

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -113,6 +113,9 @@
             if (options.target) {
                 $container = $('#' + options.target);
                 $dropdown.appendTo($container);
+            } else if (options.after) {
+                $container = $dropdown;
+                $element.after($dropdown);
             } else {
                 $container = $dropdown;
                 $dropdown.appendTo('body');
@@ -131,8 +134,10 @@
             var separators = options.separators || defaultOptions.separators;
             separators = separators && new RegExp('[' + separators + ']');
 
-            var floatingMenu = !options.target;
+            var floatingMenu = !options.target && !options.after;
             $dropdown.toggleClass('floating-menu', floatingMenu);
+
+            $dropdown.toggleClass('after-menu', options.after);
 
             options.onSelect = options.onSelect || function (item) {
                 return item.toString();
@@ -451,9 +456,11 @@
                 }
             }));
 
-            $window.on('scroll.autocomplete', positionMenu);
-            $window.on('resize.autocomplete', positionMenu);
-            $dropdown.on('scroll.autocomplete', positionMenu);
+            if (floatingMenu) {
+                $window.on('scroll.autocomplete', positionMenu);
+                $window.on('resize.autocomplete', positionMenu);
+                $dropdown.on('scroll.autocomplete', positionMenu);
+            }
 
             $element.on('blur.autocomplete', function (e) {
                 if (menuShown() && mouseInDropdown && !keyClose) {
@@ -615,7 +622,9 @@
                 if (newValue.length) {
                     $dropdown.append(renderSuggestions($dropdown, newValue));
                     selectSuggestion(0);
-                    positionMenu();
+                    if (floatingMenu) {
+                        positionMenu();
+                    }
                     menuShown(true);
                 } else {
                     menuShown(false);

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -43,7 +43,8 @@
         pageUp: 33,
         pageDown: 34,
         enter: 13,
-        tab: 9
+        tab: 9,
+        shift: 16
     };
 
     var defaultOptions = {

--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -116,6 +116,7 @@
             } else if (options.after) {
                 $container = $dropdown;
                 $element.after($dropdown);
+                $dropdown.addClass('after-menu');
             } else {
                 $container = $dropdown;
                 $dropdown.appendTo('body');
@@ -136,8 +137,6 @@
 
             var floatingMenu = !options.target && !options.after;
             $dropdown.toggleClass('floating-menu', floatingMenu);
-
-            $dropdown.toggleClass('after-menu', options.after);
 
             options.onSelect = options.onSelect || function (item) {
                 return item.toString();

--- a/test/knockout.autocomplete.spec.js
+++ b/test/knockout.autocomplete.spec.js
@@ -304,4 +304,28 @@ describe('knockout.autocomplete', function () {
             });
         });
     });
+
+    describe('place after element', function () {
+        beforeEach(function () {
+            $testElement = useTestElement('<input data-bind="autocomplete: { data: keywords, minLength: 0, after: true }" value="">');
+            viewModel = {
+                data: ko.observable(keywords)
+            };
+            ko.applyBindings(viewModel, $testElement[0]);
+        });
+
+        describe('added autocomplete element', function () {
+            it('element should have class \'after-menu\'', function () {
+                expect($('.after-menu').length, 'to be greater than', 0);
+            });
+            it('element is placed after target element', function () {
+                var previousElement = $('.after-menu').prev();
+                expect(previousElement[0].tagName, 'to be', "INPUT");
+            });
+            it('should not listen for scroll and resize events on window', function () {
+                var events = $._data(window, 'events');
+                expect(events, 'to be', undefined);
+            });
+        });
+    });
 });


### PR DESCRIPTION
This allows to have the autocomplete being positioned absolute but relative to a container surrounding both input and autocomplete. This also solves a specific issue where the dropdown didn't follow when scrolling inside an element. By having it absolute to the next relative, the browser (css) does that for us without listening for scroll or resize events.