### PR TITLE
Fixes issue with suggestions element scroll position

### DIFF
--- a/lib/knockout.autocomplete.js
+++ b/lib/knockout.autocomplete.js
@@ -582,6 +582,8 @@
                 var left = offset.left;
                 var right = left + dropdownWidth;
                 var bottom = null;
+                var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+                var scrollLeft = window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft || 0;
 
                 if ((mobileSafari && spaceBelow < 600) || (dropdownHeight > spaceBelow)) {
                     // Place above
@@ -591,16 +593,16 @@
                 if (right > $window.width()) {
                     left = Math.max($window.width() - dropdownWidth, 0);
                 } else {
-                    left -= document.body.scrollLeft;
+                    left -= scrollLeft;
                 }
 
                 // Constrain the menu to the viewport
-                if (top < document.body.scrollTop) {
+                if (top < scrollTop) {
                     // constrained by bottom
-                    top = document.body.scrollTop;
+                    top = scrollTop;
                     bottom = $window.height() - (offset.top - 5);
                 } else {
-                    top -= document.body.scrollTop;
+                    top -= scrollTop;
                 }
 
                 if (top + dropdownHeight > windowHeight) {


### PR DESCRIPTION
The issue stems from using document.body.scrollTop. That function has been deprecated in modern browsers and seems to always return 0, no matter the scroll position of the viewport.  
  
Replaced with window.pageYOffset, but gracefully falls back to older functions if needed.